### PR TITLE
Updates for Xcode 6.1 - Removing Compiler Warnings

### DIFF
--- a/UAModalPanel.xcodeproj/project.pbxproj
+++ b/UAModalPanel.xcodeproj/project.pbxproj
@@ -28,7 +28,6 @@
 		E65CAB3514CFB98C004F3776 /* UAViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E65CAB2414CFB98C004F3776 /* UAViewController.m */; };
 		E65CAB3614CFB98C004F3776 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = E65CAB2614CFB98C004F3776 /* main.m */; };
 		E65CAB3A14CFB98C004F3776 /* UAAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = E65CAB2F14CFB98C004F3776 /* UAAppDelegate.m */; };
-		E65CAB3B14CFB98C004F3776 /* UAModalPanel-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E65CAB3014CFB98C004F3776 /* UAModalPanel-Info.plist */; };
 		E65CAB3C14CFB98C004F3776 /* UrbanApps.png in Resources */ = {isa = PBXBuildFile; fileRef = E65CAB3214CFB98C004F3776 /* UrbanApps.png */; };
 		E65CAB4314CFB9A8004F3776 /* UAViewController_iPhone.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65CAB3D14CFB9A8004F3776 /* UAViewController_iPhone.xib */; };
 		E65CAB4414CFB9A8004F3776 /* UAViewController_iPad.xib in Resources */ = {isa = PBXBuildFile; fileRef = E65CAB3F14CFB9A8004F3776 /* UAViewController_iPad.xib */; };
@@ -254,7 +253,7 @@
 		E64F51F814BA98FA009CB18D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0420;
+				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Urban Apps";
 			};
 			buildConfigurationList = E64F51FB14BA98FA009CB18D /* Build configuration list for PBXProject "UAModalPanel" */;
@@ -282,7 +281,6 @@
 				E65CAB1A14CFB930004F3776 /* close.png in Resources */,
 				E65CAB1B14CFB930004F3776 /* close@2x.png in Resources */,
 				E65CAB3414CFB98C004F3776 /* UAExampleView.xib in Resources */,
-				E65CAB3B14CFB98C004F3776 /* UAModalPanel-Info.plist in Resources */,
 				E65CAB3C14CFB98C004F3776 /* UrbanApps.png in Resources */,
 				E65CAB4314CFB9A8004F3776 /* UAViewController_iPhone.xib in Resources */,
 				E65CAB4414CFB9A8004F3776 /* UAViewController_iPad.xib in Resources */,
@@ -348,9 +346,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -360,10 +365,15 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -373,13 +383,24 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";

--- a/UAModalPanel/Panel/Categories/UIView+JMNoise.m
+++ b/UAModalPanel/Panel/Categories/UIView+JMNoise.m
@@ -50,8 +50,13 @@ static UIImage * JMNoiseImage;
         NSUInteger imageDimension = imageScale * kNoiseTileDimension;
 
         CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
-        CGContextRef context = CGBitmapContextCreate(nil,imageDimension,imageDimension,8,0,
-                                                     colorSpace,kCGImageAlphaPremultipliedLast);
+        CGContextRef context = CGBitmapContextCreate(nil,
+                                                     imageDimension,
+                                                     imageDimension,
+                                                     8,
+                                                     0,
+                                                     colorSpace,
+                                                     (unsigned int)kCGImageAlphaPremultipliedLast);
         CFRelease(colorSpace);
 
         for (int i=0; i<(kNoiseTileDimension * kNoiseIntensity); i++)
@@ -103,7 +108,7 @@ static UIImage * JMNoiseImage;
     [noiseLayer setFrame:self.bounds];
     noiseLayer.masksToBounds = YES;
     noiseLayer.opacity = opacity;
-    [self.layer insertSublayer:noiseLayer atIndex:layerIndex];
+    [self.layer insertSublayer:noiseLayer atIndex:(unsigned int) layerIndex];
 }
 
 - (void)applyNoiseWithOpacity:(CGFloat)opacity;

--- a/UAModalPanel/Panel/Panels/UAModalPanel.m
+++ b/UAModalPanel/Panel/Panels/UAModalPanel.m
@@ -79,7 +79,7 @@
 #pragma mark - Description
 
 - (NSString *)description {
-	return [NSString stringWithFormat:@"<%@ %d>", [[self class] description], self.tag];
+	return [NSString stringWithFormat:@"<%@ %ld>", [[self class] description], (long)self.tag];
 }
 
 #pragma mark - Accessors
@@ -312,7 +312,7 @@
 	// Show the view right away
     [UIView animateWithDuration:0.3
 						  delay:0.0
-						options:UIViewAnimationCurveEaseOut
+						options:UIViewAnimationOptionCurveEaseIn
 					 animations:^{
 						 self.alpha = 1.0;
 						 self.contentContainer.center = self.center;

--- a/UAModalPanel/Panel/Panels/UATitledModalPanel.m
+++ b/UAModalPanel/Panel/Panels/UATitledModalPanel.m
@@ -43,7 +43,7 @@
 		self.headerLabel.textColor = [UIColor whiteColor];
 		self.headerLabel.shadowColor = [UIColor blackColor];
 		self.headerLabel.shadowOffset = CGSizeMake(0, -1);
-		self.headerLabel.textAlignment = UITextAlignmentCenter;
+		self.headerLabel.textAlignment = NSTextAlignmentCenter;
 		[self.titleBar addSubview:self.headerLabel];
 
 		
@@ -94,7 +94,7 @@
 	UADebugLog(@"Fading in content for modalPanel: %@", self);
 	[UIView animateWithDuration:0.2
 						  delay:0.0
-						options:UIViewAnimationCurveEaseIn
+						options:UIViewAnimationOptionCurveEaseIn
 					 animations:^{
 						 self.contentView.alpha = 1.0;
 						 self.titleBar.alpha = 1.0;


### PR DESCRIPTION
Hi! I'm Fernando, this is my first pull request, so my apologies if I had changed something in the wrong way, My initial idea with these changes was to remove some warnings I had in my xCode (6.1), compiling for iOS 8.1

Thank you so much for publish this control, it helped me a lot.
## Fernando Sosa.

Changes Description

Xcode 6.1 Compiler options added in order to help developers to find
and fix possible warnings.

Explicit cast to unsigned int were added in order to remove compiler
warnings.

options:UIViewAnimationCurveEaseOut
was replaced by
options:UIViewAnimationOptionCurveEaseIn

UITextAlignmentCenter
was replaced by
NSTextAlignmentCenter
